### PR TITLE
WiP: Add DTO codegen

### DIFF
--- a/build-logic/dependencies/src/main/kotlin/Deps.kt
+++ b/build-logic/dependencies/src/main/kotlin/Deps.kt
@@ -4,7 +4,7 @@ object Deps {
     const val compileSdkVersion = 31
     const val minSdkVersion = 21
 
-    private const val kotlinVersion = "1.6.10"
+    private const val kotlinVersion = "1.6.0"
     private const val coroutinesVersion = "1.6.0-RC"
     private const val serializationVersion = "1.3.1"
     private const val nodejsExternalsVersion = "0.0.7"

--- a/ksp/src/main/kotlin/com/y9vad9/implier/AnnotationsVisitor.kt
+++ b/ksp/src/main/kotlin/com/y9vad9/implier/AnnotationsVisitor.kt
@@ -45,5 +45,11 @@ class AnnotationsVisitor(private val codeGenerator: CodeGenerator) : KSVisitorVo
                 classDeclaration
             )
         }
+
+        if (classDeclaration.isAnnotationPresent(DtoImpl::class)) {
+            DtoAnnotatedClassProcessor.process(
+                classDeclaration.getAnnotationsByType(DtoImpl::class).first(), codeGenerator, classDeclaration
+            )
+        }
     }
 }

--- a/ksp/src/main/kotlin/com/y9vad9/implier/annotations/processor/DtoAnnotatedClassProcessor.kt
+++ b/ksp/src/main/kotlin/com/y9vad9/implier/annotations/processor/DtoAnnotatedClassProcessor.kt
@@ -1,0 +1,36 @@
+package com.y9vad9.implier.annotations.processor
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.Modifier
+import com.y9vad9.implier.Dto
+import com.y9vad9.implier.DtoImpl
+import com.y9vad9.implier.codegen.DtoFileCodeGeneration
+import com.y9vad9.implier.codegen.DtoFileCodeGeneration.generate
+import java.io.OutputStreamWriter
+
+object DtoAnnotatedClassProcessor : AnnotatedClassProcessor<DtoImpl> {
+    override fun process(annotation: DtoImpl, codeGenerator: CodeGenerator, classDeclaration: KSClassDeclaration) {
+        validateClassDeclaration(classDeclaration)
+
+        codeGenerator.createNewFile(
+            Dependencies(false),
+            classDeclaration.packageName.asString(),
+            "Dto${classDeclaration.simpleName.asString()}"
+        ).use { output ->
+            OutputStreamWriter(output).use { writer ->
+                DtoFileCodeGeneration.Data(Dto::class, annotation.visibility, classDeclaration).generate()
+                    .writeTo(writer)
+            }
+        }
+    }
+
+    private fun validateClassDeclaration(classDeclaration: KSClassDeclaration) {
+        if (classDeclaration.classKind == ClassKind.CLASS && Modifier.ABSTRACT !in classDeclaration.modifiers)
+            throw IllegalStateException("Unable to create realization from non-abstract class")
+        else if (classDeclaration.classKind != ClassKind.INTERFACE)
+            throw IllegalStateException("Unable to create realization from ${classDeclaration.classKind}.")
+    }
+}

--- a/ksp/src/main/kotlin/com/y9vad9/implier/annotations/processor/ImmutableAnnotatedClassProcessor.kt
+++ b/ksp/src/main/kotlin/com/y9vad9/implier/annotations/processor/ImmutableAnnotatedClassProcessor.kt
@@ -5,6 +5,7 @@ import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.Modifier
+import com.y9vad9.implier.Immutable
 import com.y9vad9.implier.ImmutableImpl
 import com.y9vad9.implier.codegen.ImplementationFileCodeGeneration
 import com.y9vad9.implier.codegen.ImplementationFileCodeGeneration.generate
@@ -28,7 +29,7 @@ object ImmutableAnnotatedClassProcessor : AnnotatedClassProcessor<ImmutableImpl>
         ).use { output ->
             OutputStreamWriter(output).use { writer ->
                 ImplementationFileCodeGeneration.Data(
-                    mutable = false,
+                    marker = Immutable::class,
                     declaration = classDeclaration,
                     visibility = annotation.visibility
                 ).generate().writeTo(writer)

--- a/ksp/src/main/kotlin/com/y9vad9/implier/annotations/processor/MutableAnnotatedClassProcessor.kt
+++ b/ksp/src/main/kotlin/com/y9vad9/implier/annotations/processor/MutableAnnotatedClassProcessor.kt
@@ -5,6 +5,7 @@ import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.Modifier
+import com.y9vad9.implier.Mutable
 import com.y9vad9.implier.MutableImpl
 import com.y9vad9.implier.codegen.ImplementationFileCodeGeneration
 import com.y9vad9.implier.codegen.ImplementationFileCodeGeneration.generate
@@ -23,7 +24,7 @@ object MutableAnnotatedClassProcessor : AnnotatedClassProcessor<MutableImpl> {
             "Mutable${classDeclaration.simpleName.asString()}"
         ).use { output ->
             OutputStreamWriter(output).use { writer ->
-                ImplementationFileCodeGeneration.Data(true, annotation.visibility, classDeclaration).generate()
+                ImplementationFileCodeGeneration.Data(marker = Mutable::class, annotation.visibility, classDeclaration).generate()
                     .writeTo(writer)
             }
         }

--- a/ksp/src/main/kotlin/com/y9vad9/implier/codegen/DtoFileCodeGeneration.kt
+++ b/ksp/src/main/kotlin/com/y9vad9/implier/codegen/DtoFileCodeGeneration.kt
@@ -74,7 +74,7 @@ object DtoFileCodeGeneration :
                     addProperty(
                         PropertySpec.builder(propertyName, propertyType)
                             .mutable(true)
-                            .initializer("$propertyName")
+                            .initializer(propertyName)
                             .build()
                     )
                 }

--- a/ksp/src/main/kotlin/com/y9vad9/implier/codegen/DtoFileCodeGeneration.kt
+++ b/ksp/src/main/kotlin/com/y9vad9/implier/codegen/DtoFileCodeGeneration.kt
@@ -1,0 +1,92 @@
+package com.y9vad9.implier.codegen
+
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.Modifier
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.ksp.KotlinPoetKspPreview
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.y9vad9.implier.Mutable
+import com.y9vad9.implier.Visibility
+import com.y9vad9.implier.codegen.DtoFileCodeGeneration.generate
+import kotlin.reflect.KClass
+
+object DtoFileCodeGeneration :
+    FileCodeGeneration<DtoFileCodeGeneration.Data> {
+    fun s(){
+
+
+    }
+    override fun Data.generate(): FileSpec {
+        return FileSpec.builder(packageName, simpleName)
+            .addType(
+                TypeSpec.classBuilder(name)
+                    .addModifiers(if(visibility == Visibility.PUBLIC) KModifier.PUBLIC else KModifier.INTERNAL)
+                    .applyParent()
+                    .applyConstructor()
+                    .build()
+            ).addFunction(
+                FunSpec.builder("toDto")
+                    .addModifiers(if(visibility == Visibility.PUBLIC) KModifier.PUBLIC else KModifier.INTERNAL)
+                    .receiver(ClassName(declaration.packageName.asString(), declaration.simpleName.asString()))
+                    .returns(ClassName(declaration.packageName.asString(), name))
+                    .addCode("return $name(${formatConstructorArguments()})")
+                    .build()
+            ).addFunction(
+                FunSpec.builder("toPatched")
+                    .addParameter("patch", className)
+                    .addModifiers(if(visibility == Visibility.PUBLIC) KModifier.PUBLIC else KModifier.INTERNAL)
+                    .receiver(ClassName(declaration.packageName.asString(), declaration.simpleName.asString()))
+                    .returns(className)
+                    .addCode(CodeBlock.builder()
+                        .addStatement("val isMutable = this is Mutable${declaration.simpleName.asString()}")
+                        .addStatement("val base = if(isMutable) this as Mutable${declaration.simpleName.asString()} else this.toMutable()")
+                        .also { builder ->
+                            for (property in declaration.getAllProperties()) {
+                                builder.addStatement("patch.${property.simpleName.asString()}?.let{ ")
+                                    .indent().addStatement("base.${property.simpleName.asString()} = it").unindent()
+                                    .addStatement("}")
+                            }
+                        }
+                        .addStatement("return if(isMutable) this else base.toImmutable()")
+                        .build())
+                    .build()
+            )
+            .build()
+    }
+
+    @OptIn(KotlinPoetKspPreview::class)
+    class Data(
+        val marker: KClass<*>,
+        val visibility: Visibility,
+        declaration: KSClassDeclaration
+    ) : FileCodeGeneration.Data(declaration) {
+        val name: String get() = marker.simpleName + simpleName
+
+        fun TypeSpec.Builder.applyParent(): TypeSpec.Builder =
+            addSuperinterface(marker.asClassName().parameterizedBy(declaration.toClassName()))
+
+        fun TypeSpec.Builder.applyConstructor(): TypeSpec.Builder {
+            return primaryConstructor(FunSpec.constructorBuilder().apply {
+                for (property in declaration.getAllProperties()) {
+                    val propertyName = property.simpleName.asString()
+                    val propertyType = property.type.resolve().toClassName().copy(nullable = true)
+                    addParameter(
+                        ParameterSpec.builder(propertyName, propertyType).build()
+                    )
+                    addProperty(
+                        PropertySpec.builder(propertyName, propertyType)
+                            .mutable(true)
+                            .initializer("$propertyName")
+                            .build()
+                    )
+                }
+            }.build())
+        }
+
+        fun formatConstructorArguments(): String {
+            return declaration.getAllProperties().joinToString(", ") { it.simpleName.asString() }
+        }
+    }
+}

--- a/ksp/src/main/kotlin/com/y9vad9/implier/codegen/DtoFileCodeGeneration.kt
+++ b/ksp/src/main/kotlin/com/y9vad9/implier/codegen/DtoFileCodeGeneration.kt
@@ -14,10 +14,6 @@ import kotlin.reflect.KClass
 
 object DtoFileCodeGeneration :
     FileCodeGeneration<DtoFileCodeGeneration.Data> {
-    fun s(){
-
-
-    }
     override fun Data.generate(): FileSpec {
         return FileSpec.builder(packageName, simpleName)
             .addType(

--- a/src/main/kotlin/com/y9vad9/implier/annotations.kt
+++ b/src/main/kotlin/com/y9vad9/implier/annotations.kt
@@ -1,6 +1,5 @@
 package com.y9vad9.implier
 
-
 /**
  * Marks that object should be able to mutate.
  * Generates `toMutable()` function for creating mutable variant of object and
@@ -60,3 +59,12 @@ annotation class DSLBuilderImpl(
         PROPERTY_ACCESS, WITH_ACCESSORS, WITHOUT_ACCESSORS
     }
 }
+
+/**
+ * Marks that object should be able to (partially) mutate using DTOs as patch objects.
+ * Generates `toDto()` function for creating mutable variant of object
+ * with nullable members and DTO variant of annotated interface.
+ * @param visibility - Visibility of generated class & function.
+ */
+@Target(allowedTargets = [AnnotationTarget.CLASS])
+annotation class DtoImpl(val visibility: Visibility = Visibility.PUBLIC)

--- a/src/main/kotlin/com/y9vad9/implier/markers.kt
+++ b/src/main/kotlin/com/y9vad9/implier/markers.kt
@@ -1,6 +1,6 @@
 package com.y9vad9.implier
 
 interface GenericMarker<T>
-interface Mutable<T>: GenericMarker<T>
-interface Immutable<T>: GenericMarker<T>
-interface Dto<T>: GenericMarker<T>
+interface Mutable<T> : GenericMarker<T>
+interface Immutable<T> : GenericMarker<T>
+interface Dto<T> : GenericMarker<T>

--- a/src/main/kotlin/com/y9vad9/implier/markers.kt
+++ b/src/main/kotlin/com/y9vad9/implier/markers.kt
@@ -1,0 +1,6 @@
+package com.y9vad9.implier
+
+interface GenericMarker<T>
+interface Mutable<T>: GenericMarker<T>
+interface Immutable<T>: GenericMarker<T>
+interface Dto<T>: GenericMarker<T>

--- a/test/src/test/kotlin/Sample.kt
+++ b/test/src/test/kotlin/Sample.kt
@@ -4,6 +4,7 @@ import com.y9vad9.implier.*
 
 @FactoryFunctionImpl(Visibility.INTERNAL)
 @ImmutableImpl(Visibility.INTERNAL)
+@DtoImpl(Visibility.INTERNAL)
 @MutableImpl(Visibility.INTERNAL)
 @BuilderImpl(visibility = Visibility.INTERNAL)
 @DSLBuilderImpl("sampleDSL", type = DSLBuilderImpl.Type.WITH_ACCESSORS, visibility = Visibility.INTERNAL)


### PR DESCRIPTION
Nice work! Thought best to try contributing for my personal needs VS forking. This  WiP PR adds support for generating DTOs, i.e. #9 nullable mutables that can be used for partial updates, e.g.

```kotlin
@FactoryFunctionImpl(Visibility.INTERNAL)
@ImmutableImpl(Visibility.INTERNAL)
@DtoImpl(Visibility.INTERNAL)
@MutableImpl(Visibility.INTERNAL)
@BuilderImpl(visibility = Visibility.INTERNAL)
@DSLBuilderImpl("sampleDSL", type = DSLBuilderImpl.Type.WITH_ACCESSORS, visibility = Visibility.INTERNAL)
interface Sample {
    val sample: String
    val number: Int
}
```

Will generate:

```kotlin
internal class DtoSample(
  public var sample: String?,
  public var number: Int?
) : Dto<Sample>

internal fun Sample.toDto(): DtoSample = DtoSample(sample, number)

internal fun Sample.toPatched(patch: Sample): Sample {
  val isMutable = this is MutableSample
  val base = if(isMutable) this as MutableSample else this.toMutable()
  patch.sample?.let{ 
    base.sample = it
  }
  patch.number?.let{ 
    base.number = it
  }
  return if(isMutable) this else base.toImmutable()
}

```

The `toPatched` shouldn't be so dependent on the generated `MutableSample` of course, see https://github.com/y9vad9/implier/issues/11
